### PR TITLE
Restore keyboard shortcut for create post (Cmd/Ctrl + Enter)

### DIFF
--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -244,7 +244,6 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
   };
 
 // Re-added keyboard shortcut for create post (Cmd/Ctrl + Enter) for the keyboard warriors :)
-// The shortcut only triggers when focus is in an editable field (contenteditable/textarea/input).
 useHotkeys("mod+enter", () => handleCreatePost(), {
   enableOnContentEditable: true
 });


### PR DESCRIPTION
is there any particular reason why this hotkey was removed?

proposing to re-add the shortcut for submitting posts on web to make life a little bit easier for us keyboard warriors!