### PR TITLE
fix: add object-cover to avatar images

### DIFF
--- a/packages/web/src/components/Account/DeletedDetails.tsx
+++ b/packages/web/src/components/Account/DeletedDetails.tsx
@@ -16,7 +16,7 @@ const DeletedDetails = ({ account }: DeletedDetailsProps) => {
       <div className="-mt-14 sm:-mt-24 relative ml-5 size-20 sm:size-36">
         <Image
           alt={account.address}
-          className="size-20 rounded-xl bg-gray-200 ring-3 ring-gray-50 sm:size-36 dark:bg-gray-700 dark:ring-black"
+          className="size-20 rounded-xl bg-gray-200 object-cover ring-3 ring-gray-50 sm:size-36 dark:bg-gray-700 dark:ring-black"
           height={128}
           src={`${STATIC_IMAGES_URL}/suspended.webp`}
           width={128}

--- a/packages/web/src/components/Account/Details.tsx
+++ b/packages/web/src/components/Account/Details.tsx
@@ -80,7 +80,7 @@ const Details = ({
         <div className="-mt-14 sm:-mt-24 relative ml-4 size-20 sm:size-36 md:ml-5">
           <Image
             alt={account.address}
-            className="size-20 cursor-pointer rounded-full bg-gray-200 ring-3 ring-gray-50 sm:size-36 dark:bg-gray-700 dark:ring-black"
+            className="size-20 cursor-pointer rounded-full bg-gray-200 object-cover ring-3 ring-gray-50 sm:size-36 dark:bg-gray-700 dark:ring-black"
             height={128}
             onClick={handleShowLightBox}
             src={getAvatar(account, TRANSFORMS.AVATAR_BIG)}

--- a/packages/web/src/components/Post/PostAvatar.tsx
+++ b/packages/web/src/components/Post/PostAvatar.tsx
@@ -32,7 +32,7 @@ const PostAvatar = ({
         alt={account.address}
         className={cn(
           quoted ? "mt-0.5 size-8" : "size-11",
-          "z-[1] cursor-pointer rounded-full border border-gray-200 bg-gray-200 dark:border-gray-800"
+          "z-[1] cursor-pointer rounded-full border border-gray-200 bg-gray-200 object-cover dark:border-gray-800"
         )}
         height={quoted ? 25 : 44}
         loading="lazy"


### PR DESCRIPTION
Prevents avatar images from being distorted when aspect ratio differs.


example with user [lulita13](https://palus.app/u/lulita13):

<img width="1070" height="671" alt="image" src="https://github.com/user-attachments/assets/3b75abac-bfa3-4302-9bb8-d46e3f763815" />

(it's very unusual to see people with profile pictures that aren't 1:1 but there are still some cases left)
