### PR TITLE
support simple mentions (ex. @username) in profile bios

### DIFF
--- a/packages/web/src/data/regex.ts
+++ b/packages/web/src/data/regex.ts
@@ -6,12 +6,12 @@ const RESTRICTED_SYMBOLS = "☑️✓✔✅";
 // line or immediately after whitespace.
 const MATCH_BEHIND = regexLookbehindAvailable ? "(?<=^|\\s)" : "";
 
-const MENTION_NAMESPACE = "\\w+\\/";
+const MENTION_NAMESPACE = "(?:\\w+\\/)?"; // Make namespace optional
 const MENTION_BODY = "([\\dA-Za-z]\\w{1,25})";
 const EDITOR_MENTION = "([\\dA-Za-z]\\w*)"; // This will start searching for mentions after the first character
 
 export const Regex = {
-  // Match string like @lens/someone.
+  // Match string like @lens/someone or @someone.
   accountMention: new RegExp(
     `${MATCH_BEHIND}@${MENTION_NAMESPACE}${MENTION_BODY}`,
     "g"

--- a/packages/web/src/helpers/getMentions.ts
+++ b/packages/web/src/helpers/getMentions.ts
@@ -10,14 +10,25 @@ const getMentions = (text: string): PostMentionFragment[] => {
   const mentions = text.match(Regex.accountMention) ?? [];
 
   return mentions.map((mention) => {
-    const handle = mention
-      .substring(mention.lastIndexOf("/") + 1)
-      .toLowerCase();
+    const hasSeparator = mention.includes("/");
+    let namespace = "";
+    let handle = "";
+
+    if (hasSeparator) {
+      // Format: @namespace/handle
+      const parts = mention.substring(1).split("/"); // Remove @ and split
+      namespace = parts[0].toLowerCase();
+      handle = parts[1].toLowerCase();
+    } else {
+      // Format: @handle
+      handle = mention.substring(1).toLowerCase(); // Remove @ 
+      namespace = handle; // Use handle as namespace for simple mentions
+    }
 
     return {
-      account: "",
-      namespace: "",
-      replace: { from: handle, to: handle }
+      account: handle,
+      namespace: namespace,
+      replace: { from: mention, to: mention }
     } as AccountMentionFragment;
   });
 };


### PR DESCRIPTION
currently app only recognizes namespaced mentions (e.g., @lens/username) in profile bios and descriptions but not simple mentions (e.g., @username), which prevents accounts from properly tagging other users when they don't include the namespace prefix.

changes:
- users can tag accounts using @username in profile bios/descriptions
- existing @namespace/username mentions continue to work as before
- regex improvement benefits all parts of the app that use Regex.accountMention